### PR TITLE
Aktualizacja bundlera do najnowszej wersji

### DIFF
--- a/bootstrap-vagrant.sh
+++ b/bootstrap-vagrant.sh
@@ -47,7 +47,7 @@ echo ====================== Sciagam gemy i uzupelniam baze danych
 apt-get install --yes g++
 # pakiety potrzebne dla wkhtmltopdf
 apt-get install --yes libfontconfig1 libxrender1
-sudo -H -u vagrant -i bash -c "gem install bundle"
+sudo -H -u vagrant -i bash -c "gem install bundler"
 sudo -H -u vagrant -i bash -c "cd /ziher; bundle install"
 sudo -H -u vagrant -i bash -c "cd /ziher; rake db:create:all"
 sudo -H -u vagrant -i bash -c "cd /ziher; rake db:setup"


### PR DESCRIPTION
Wpisanie `gem install bundle` bez `r` nie powoduje aktualizacji bundlera do najnowszej wersji, jedynie upewnia się, że gem o nazwie `bundler` jest zainstalowany w wersji co najmniej 0.0.
https://rubygems.org/gems/bundle